### PR TITLE
fix: non-compliant to XDG Base directory specification

### DIFF
--- a/Settings/Settings.qml
+++ b/Settings/Settings.qml
@@ -7,7 +7,7 @@ import qs.Services
 Singleton {
 
     property string shellName: "Noctalia"
-    property string settingsDir: Quickshell.env("HOME") + "/.config/" + shellName + "/"
+    property string settingsDir: (Quickshell.env("XDG_CONFIG_HOME") || Quickshell.env("HOME") + "/.config") + "/" + shellName + "/"
     property string settingsFile: settingsDir + "Settings.json"
     property var settings: settingAdapter
 


### PR DESCRIPTION
Checks if `XDG_CONFIG_HOME` is unset or empty before defaulting to `~/.config`

https://specifications.freedesktop.org/basedir-spec/latest/#variables