### PR TITLE
Wallpaper improvements

### DIFF
--- a/Widgets/Background.qml
+++ b/Widgets/Background.qml
@@ -6,28 +6,38 @@ import qs.Settings
 
 ShellRoot {
     property string wallpaperSource: WallpaperManager.currentWallpaper !== "" && !Settings.settings.useSWWW ? WallpaperManager.currentWallpaper : ""
-    PanelWindow {
-        visible: wallpaperSource !== ""
-        anchors {
-            bottom: true
-            top: true
-            right: true
-            left: true
-        }
-        margins {
-            top: 0
-        }
-        color: "transparent"
-        WlrLayershell.layer: WlrLayer.Background
-        WlrLayershell.exclusionMode: ExclusionMode.Ignore
-        WlrLayershell.namespace: "quickshell-wallpaper"
-        Image {
-            anchors.fill: parent
-            fillMode: Image.PreserveAspectCrop
-            source: wallpaperSource
+
+    Variants {
+        model: Quickshell.screens
+
+        PanelWindow {
+            required property ShellScreen modelData
+
             visible: wallpaperSource !== ""
-            cache: true
-            smooth: true
+            anchors {
+                bottom: true
+                top: true
+                right: true
+                left: true
+            }
+            margins {
+                top: 0
+            }
+            color: "transparent"
+            screen: modelData
+            WlrLayershell.layer: WlrLayer.Background
+            WlrLayershell.exclusionMode: ExclusionMode.Ignore
+            WlrLayershell.namespace: "quickshell-wallpaper"
+            Image {
+                anchors.fill: parent
+                fillMode: Image.PreserveAspectCrop
+                source: wallpaperSource
+                visible: wallpaperSource !== ""
+                cache: true
+                smooth: true
+            }
         }
     }
+
+
 }

--- a/Widgets/LockScreen.qml
+++ b/Widgets/LockScreen.qml
@@ -141,9 +141,16 @@ WlSessionLock {
         FastBlur {
             anchors.fill: parent
             source: lockBgImage
-            radius: 48 // Adjust blur strength as needed
+            radius: 22 // Adjust blur strength as needed
             transparentBorder: true
         }
+        Rectangle {
+                anchors.fill: parent
+                color: Qt.rgba(
+                    Theme.backgroundPrimary.r,
+                    Theme.backgroundPrimary.g,
+                    Theme.backgroundPrimary.b, 0.6)
+            }
         // Main content container (moved up, Rectangle removed)
         ColumnLayout {
             anchors.centerIn: parent

--- a/Widgets/Overview.qml
+++ b/Widgets/Overview.qml
@@ -7,33 +7,48 @@ import qs.Settings
 
 ShellRoot {
     property string wallpaperSource: WallpaperManager.currentWallpaper !== "" && !Settings.settings.useSWWW ? WallpaperManager.currentWallpaper : ""
-    PanelWindow {
-        visible: wallpaperSource !== ""
-        anchors {
-            top: true
-            bottom: true
-            right: true
-            left: true
-        }
-        color: "transparent"
-        WlrLayershell.layer: WlrLayer.Background
-        WlrLayershell.exclusionMode: ExclusionMode.Ignore
-        WlrLayershell.namespace: "quickshell-overview"
-        Image {
-            id: bgImage
-            anchors.fill: parent
-            fillMode: Image.PreserveAspectCrop
-            source: wallpaperSource
-            cache: true
-            smooth: true
-            visible: wallpaperSource !== "" // Show the original for FastBlur input
-        }
-        FastBlur {
-            anchors.fill: parent
+
+    Variants {
+        model: Quickshell.screens
+
+        PanelWindow {
+            required property ShellScreen modelData
+
             visible: wallpaperSource !== ""
-            source: bgImage
-            radius: 24 // Adjust blur strength as needed
-            transparentBorder: true
+            anchors {
+                top: true
+                bottom: true
+                right: true
+                left: true
+            }
+            color: "transparent"
+            screen: modelData
+            WlrLayershell.layer: WlrLayer.Background
+            WlrLayershell.exclusionMode: ExclusionMode.Ignore
+            WlrLayershell.namespace: "quickshell-overview"
+            Image {
+                id: bgImage
+                anchors.fill: parent
+                fillMode: Image.PreserveAspectCrop
+                source: wallpaperSource
+                cache: true
+                smooth: true
+                visible: wallpaperSource !== "" // Show the original for FastBlur input
+            }
+            FastBlur {
+                anchors.fill: parent
+                visible: wallpaperSource !== ""
+                source: bgImage
+                radius: 18 // Adjust blur strength as needed
+                transparentBorder: true
+            }
+            Rectangle {
+                anchors.fill: parent
+                color: Qt.rgba(
+                    Theme.backgroundPrimary.r,
+                    Theme.backgroundPrimary.g,
+                    Theme.backgroundPrimary.b, 0.6)
+            }
         }
     }
 }


### PR DESCRIPTION
I'm not using SWWW as I don't really change my wallpaper that often.
This PR addresses a couple issues with the basic wallpaper/overview implementation when not using SWWW daemon.

- Fix: The wallpaper was only applied to the primary screen.
- Improve the look of the blurred backdrop by applying a slight tint over the image (based on theme) which makes things look better imo.
- Also tinted the lockscreen in the same way.

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/704acb61-17ba-4687-a9e4-45bafe0f5344" />
