### PR TITLE
Improve images resizing quality accross the board

### DIFF
--- a/Bar/Modules/Applauncher.qml
+++ b/Bar/Modules/Applauncher.qml
@@ -347,6 +347,7 @@ PanelWithOverlay {
                                         anchors.fill: parent
                                         fillMode: Image.PreserveAspectFit
                                         smooth: true
+                                        mipmap: true
                                         cache: false
                                         asynchronous: true
                                         source: modelData.isCalculator ? "qrc:/icons/calculate.svg" : Quickshell.iconPath(modelData.icon, "application-x-executable")

--- a/Bar/Modules/CustomTrayMenu.qml
+++ b/Bar/Modules/CustomTrayMenu.qml
@@ -115,6 +115,8 @@ PopupWindow {
                     Image {
                         Layout.preferredWidth: 16
                         Layout.preferredHeight: 16
+                        smooth: true
+                        mipmap: true
                         source: modelData?.icon ?? ""
                         visible: (modelData?.icon ?? "") !== ""
                         fillMode: Image.PreserveAspectFit

--- a/Bar/Modules/Media.qml
+++ b/Bar/Modules/Media.qml
@@ -54,6 +54,7 @@ Item {
                     anchors.margins: 1
                     fillMode: Image.PreserveAspectCrop
                     smooth: true
+                    mipmap: true
                     cache: false
                     asynchronous: true
                     sourceSize.width: 24

--- a/Bar/Modules/Taskbar.qml
+++ b/Bar/Modules/Taskbar.qml
@@ -75,6 +75,7 @@ Item {
                     anchors.centerIn: parent
                     source: getAppIcon(modelData)
                     smooth: true
+                    mipmap: true
                     visible: source.toString() !== ""
                 }
 

--- a/Widgets/Dock.qml
+++ b/Widgets/Dock.qml
@@ -155,6 +155,7 @@ PanelWindow {
                             anchors.centerIn: parent
                             source: taskbar.getAppIcon(modelData)
                             smooth: true
+                            mipmap: true
                             visible: source.toString() !== ""
                         }
 

--- a/Widgets/LockScreen/LockScreen.qml
+++ b/Widgets/LockScreen/LockScreen.qml
@@ -135,7 +135,8 @@ WlSessionLock {
             fillMode: Image.PreserveAspectCrop
             source: WallpaperManager.currentWallpaper !== "" ? WallpaperManager.currentWallpaper : ""
             cache: true
-            smooth: false
+            smooth: true
+            mipmap: false
             visible: true // source for MultiEffect
         }
 
@@ -168,6 +169,8 @@ WlSessionLock {
                     fillMode: Image.PreserveAspectCrop
                     visible: false
                     asynchronous: true
+                    mipmap: true
+                    smooth: true
                 }
                 OpacityMask {
                     anchors.fill: avatarImage

--- a/Widgets/Notification/NotificationPopup.qml
+++ b/Widgets/Notification/NotificationPopup.qml
@@ -130,6 +130,7 @@ PanelWindow {
                             anchors.margins: 4
                             fillMode: Image.PreserveAspectFit
                             smooth: true
+                            mipmap: true
                             cache: false
                             asynchronous: true
                             sourceSize.width: 36

--- a/Widgets/Overview.qml
+++ b/Widgets/Overview.qml
@@ -34,6 +34,7 @@ ShellRoot {
                 source: wallpaperSource
                 cache: true
                 smooth: true
+                mipmap: false
                 visible: wallpaperSource !== "" // Show the original for FastBlur input
             }
             MultiEffect {

--- a/Widgets/Sidebar/Config/ProfileSettings.qml
+++ b/Widgets/Sidebar/Config/ProfileSettings.qml
@@ -70,8 +70,8 @@ Rectangle {
                         visible: false
                         asynchronous: true
                         cache: false
-                        sourceSize.width: 64
-                        sourceSize.height: 64
+                        smooth: true
+                        mipmap: true
                     }
                     
                     OpacityMask {

--- a/Widgets/Sidebar/Panel/Music.qml
+++ b/Widgets/Sidebar/Panel/Music.qml
@@ -93,6 +93,7 @@ Rectangle {
                             anchors.margins: 2
                             fillMode: Image.PreserveAspectCrop
                             smooth: true
+                            mipmap: true
                             cache: false
                             asynchronous: true
                             sourceSize.width: 60

--- a/Widgets/Sidebar/Panel/System.qml
+++ b/Widgets/Sidebar/Panel/System.qml
@@ -60,8 +60,8 @@ Rectangle {
                             fillMode: Image.PreserveAspectCrop
                             asynchronous: true
                             cache: false
-                            sourceSize.width: 44
-                            sourceSize.height: 44
+                            smooth: true
+                            mipmap: true
                         }
                         maskSource: Rectangle {
                             width: 44

--- a/Widgets/Sidebar/Panel/WallpaperPanel.qml
+++ b/Widgets/Sidebar/Panel/WallpaperPanel.qml
@@ -137,8 +137,8 @@ PanelWindow {
                                     fillMode: Image.PreserveAspectCrop
                                     asynchronous: true
                                     cache: true
-                                    sourceSize.width: Math.min(width, 150)
-                                    sourceSize.height: Math.min(height, 90)
+                                    smooth: true
+                                    mipmap: true
                                 }
                                 MouseArea {
                                     anchors.fill: parent


### PR DESCRIPTION
- Using mipmap: true and smooth: true for images that are downscaled (avatar, icons, ...)
- Using mipmap: false and smooth: true for images that are potentially upscaled (background, overview, ...)
- Removed source.width and height override which leads to poor quality