### PR TITLE
Taskbar fixes + misc

### DIFF
--- a/Bar/Modules/SystemInfo.qml
+++ b/Bar/Modules/SystemInfo.qml
@@ -8,6 +8,10 @@ Row {
     spacing: 10
     visible: Settings.settings.showSystemInfoInBar
 
+    // The width calculation below is required to ensure our row width is an integer.
+    // If omitted the next component to the right might get blurry (Taskbar icons).
+    width: Math.floor(cpuUsageLayout.width + cpuTempLayout.width + memoryUsageLayout.width + (2 * 10))
+
     Row {
         id: cpuUsageLayout
         spacing: 6

--- a/Bar/Modules/Taskbar.qml
+++ b/Bar/Modules/Taskbar.qml
@@ -15,6 +15,7 @@ Item {
     // Attach custom tooltip
     StyledTooltip {
         id: styledTooltip
+        positionAbove: false
     }
 
     function getAppIcon(toplevel: Toplevel): string {
@@ -94,7 +95,8 @@ Item {
                     cursorShape: Qt.PointingHandCursor
 
                     onEntered: {
-                        styledTooltip.text = appTitle || appId;
+                        var text = appTitle || appId;
+                        styledTooltip.text = text.length > 60 ? text.substring(0, 60) + "..." : text;
                         styledTooltip.targetItem = appButton;
                         styledTooltip.tooltipVisible = true;
                     }

--- a/Components/StyledTooltip.qml
+++ b/Components/StyledTooltip.qml
@@ -16,8 +16,6 @@ Window {
     color: "transparent"
     visible: false
 
-    minimumWidth: Math.max(50, tooltipText.implicitWidth + 24)
-    minimumHeight: Math.max(50, tooltipText.implicitHeight + 16)
     property var _timerObj: null
 
     onTooltipVisibleChanged: {
@@ -36,6 +34,9 @@ Window {
     }
 
     function _showNow() {
+        width = Math.max(50, tooltipText.implicitWidth + 24)
+        height = Math.max(50, tooltipText.implicitHeight + 16)
+
         if (!targetItem) return;
 
         if (positionAbove) {

--- a/README.md
+++ b/README.md
@@ -184,7 +184,6 @@ qs ipc call globalIPC toggleIdleInhibitor
 
 You will need to install a few things to get everything working:
 
-- `qt6-5compat` for some graphical effects
 - `cava` so the audio visualizer works
 - `gpu-screen-recorder` so that the record button works
 - `xdg-desktop-portal-gnome` or any other xdg-desktop-portal


### PR DESCRIPTION
- Readme: removed requirement for qt6-5compat as it is no longer necessary.
- Taskbar vs SystemInfo: Found a weird bug where the width of the SystemInfo component would be a float, and that would affect rendering of the following widget,  the taskbar icons would be all blurry. Fixing the width of the SystemInfo to avoid this.
- Taskbar: It re-uses the same tooltip across all icons and the tooltip dimensions where not properly updated when the text changed.  Also added a basic truncate with ellipsis to avoid super large tooltip (ex: when hovering a browser icon.)