### PR TITLE
Added a way to choose on which screen the bar should be attached.

### DIFF
--- a/Bar/Bar.qml
+++ b/Bar/Bar.qml
@@ -26,224 +26,234 @@ Scope {
         Variants {
             model: Quickshell.screens
 
-            Item {
+            Loader {
                 property var modelData
-
-                PanelWindow {
-                    id: panel
-                    screen: modelData
-                    color: "transparent"
-                    implicitHeight: barBackground.height
-                    anchors.top: true
-                    anchors.left: true
-                    anchors.right: true
-
-                    visible: true
-
-                    Rectangle {
-                        id: barBackground
-                        width: parent.width
-                        height: 36
-                        color: Theme.backgroundPrimary
-                        anchors.top: parent.top
-                        anchors.left: parent.left
+                active: {
+                    if (!Settings.settings.activeScreens.length) {
+                        // If the list is empty, activate all screens
+                        return true;
                     }
+                    return Settings.settings.activeScreens.includes(modelData.name);
+                }
 
-                    Row {
-                        id: leftWidgetsRow
-                        anchors.verticalCenter: barBackground.verticalCenter
-                        anchors.left: barBackground.left
-                        anchors.leftMargin: 18
-                        spacing: 12
-
-                        SystemInfo {
-                            anchors.verticalCenter: parent.verticalCenter
-                        }
-
-                        Media {
-                            anchors.verticalCenter: parent.verticalCenter
-                        }
-
-                        Taskbar {
-                            anchors.verticalCenter: parent.verticalCenter
-                        }
-                    }
-
-                    ActiveWindow {
+                sourceComponent : Item {
+                    PanelWindow {
+                        id: panel
                         screen: modelData
+                        color: "transparent"
+                        implicitHeight: barBackground.height
+                        anchors.top: true
+                        anchors.left: true
+                        anchors.right: true
+
+                        visible: true
+
+                        Rectangle {
+                            id: barBackground
+                            width: parent.width
+                            height: 36
+                            color: Theme.backgroundPrimary
+                            anchors.top: parent.top
+                            anchors.left: parent.left
+                        }
+
+                        Row {
+                            id: leftWidgetsRow
+                            anchors.verticalCenter: barBackground.verticalCenter
+                            anchors.left: barBackground.left
+                            anchors.leftMargin: 18
+                            spacing: 12
+
+                            SystemInfo {
+                                anchors.verticalCenter: parent.verticalCenter
+                            }
+
+                            Media {
+                                anchors.verticalCenter: parent.verticalCenter
+                            }
+
+                            Taskbar {
+                                anchors.verticalCenter: parent.verticalCenter
+                            }
+                        }
+
+                        ActiveWindow {
+                            screen: modelData
+                        }
+
+                        Workspace {
+                            id: workspace
+                            screen: modelData
+                            anchors.horizontalCenter: barBackground.horizontalCenter
+                            anchors.verticalCenter: barBackground.verticalCenter
+                        }
+
+                        Row {
+                            id: rightWidgetsRow
+                            anchors.verticalCenter: barBackground.verticalCenter
+                            anchors.right: barBackground.right
+                            anchors.rightMargin: 18
+                            spacing: 12
+
+
+                            SystemTray {
+                                id: systemTrayModule
+                                shell: rootScope.shell
+                                anchors.verticalCenter: parent.verticalCenter
+                                bar: panel
+                                trayMenu: externalTrayMenu
+                            }
+
+                            CustomTrayMenu {
+                                id: externalTrayMenu
+                            }
+
+                            NotificationIcon {
+                                anchors.verticalCenter: parent.verticalCenter
+                            }
+
+                            Battery {
+                                id: widgetsBattery
+                                anchors.verticalCenter: parent.verticalCenter
+                            }
+
+                            Brightness {
+                                id: widgetsBrightness
+                                screen: modelData
+                                anchors.verticalCenter: parent.verticalCenter
+                            }
+
+                            Volume {
+                                id: widgetsVolume
+                                shell: rootScope.shell
+                                anchors.verticalCenter: parent.verticalCenter
+                            }
+
+                            ClockWidget {
+                                screen: modelData
+                                anchors.verticalCenter: parent.verticalCenter
+                            }
+
+                            PanelPopup {
+                                id: sidebarPopup
+                            }
+
+                            Button {
+                                barBackground: barBackground
+                                anchors.verticalCenter: parent.verticalCenter
+                                screen: modelData
+                                sidebarPopup: sidebarPopup
+                            }
+                        }
+
+                        Background {}
+                        Overview {}
                     }
 
-                    Workspace {
-                        id: workspace
+                    PanelWindow {
+                        id: topLeftPanel
+                        anchors.top: true
+                        anchors.left: true
+
+                        color: "transparent"
                         screen: modelData
-                        anchors.horizontalCenter: barBackground.horizontalCenter
-                        anchors.verticalCenter: barBackground.verticalCenter
-                    }
+                        margins.top: 36
+                        WlrLayershell.exclusionMode: ExclusionMode.Ignore
+                        visible: true
+                        WlrLayershell.layer: WlrLayer.Background
+                        aboveWindows: false
+                        WlrLayershell.namespace: "swww-daemon"
+                        implicitHeight: 24
 
-                    Row {
-                        id: rightWidgetsRow
-                        anchors.verticalCenter: barBackground.verticalCenter
-                        anchors.right: barBackground.right
-                        anchors.rightMargin: 18
-                        spacing: 12
-
-                        SystemTray {
-                            id: systemTrayModule
-                            shell: rootScope.shell
-                            anchors.verticalCenter: parent.verticalCenter
-                            bar: panel
-                            trayMenu: externalTrayMenu
-                        }
-
-                        CustomTrayMenu {
-                            id: externalTrayMenu
-                        }
-
-                        NotificationIcon {
-                            anchors.verticalCenter: parent.verticalCenter
-                        }
-
-                        Battery {
-                            id: widgetsBattery
-                            anchors.verticalCenter: parent.verticalCenter
-                        }
-
-                        Brightness {
-                            id: widgetsBrightness
-                            screen: modelData
-                            anchors.verticalCenter: parent.verticalCenter
-                        }
-
-                        Volume {
-                            id: widgetsVolume
-                            shell: rootScope.shell
-                            anchors.verticalCenter: parent.verticalCenter
-                        }
-
-                        ClockWidget {
-                            screen: modelData
-                            anchors.verticalCenter: parent.verticalCenter
-                        }
-
-                        PanelPopup {
-                            id: sidebarPopup
-                        }
-
-                        Button {
-                            barBackground: barBackground
-                            anchors.verticalCenter: parent.verticalCenter
-                            screen: modelData
-                            sidebarPopup: sidebarPopup
+                        Corners {
+                            id: topLeftCorner
+                            position: "bottomleft"
+                            size: 1.3
+                            fillColor: (Theme.backgroundPrimary !== undefined && Theme.backgroundPrimary !== null) ? Theme.backgroundPrimary : "#222"
+                            offsetX: -39
+                            offsetY: 0
+                            anchors.top: parent.top
+                            visible: Settings.settings.showCorners
                         }
                     }
 
-                    Background {}
-                    Overview {}
-                }
+                    PanelWindow {
+                        id: topRightPanel
+                        anchors.top: true
+                        anchors.right: true
+                        color: "transparent"
+                        screen: modelData
+                        margins.top: 36
+                        WlrLayershell.exclusionMode: ExclusionMode.Ignore
+                        visible: true
+                        WlrLayershell.layer: WlrLayer.Background
+                        aboveWindows: false
+                        WlrLayershell.namespace: "swww-daemon"
 
-                PanelWindow {
-                    id: topLeftPanel
-                    anchors.top: true
-                    anchors.left: true
+                        implicitHeight: 24
 
-                    color: "transparent"
-                    screen: modelData
-                    margins.top: 36
-                    WlrLayershell.exclusionMode: ExclusionMode.Ignore
-                    visible: true
-                    WlrLayershell.layer: WlrLayer.Background
-                    aboveWindows: false
-                    WlrLayershell.namespace: "swww-daemon"
-                    implicitHeight: 24
-
-                    Corners {
-                        id: topLeftCorner
-                        position: "bottomleft"
-                        size: 1.3
-                        fillColor: (Theme.backgroundPrimary !== undefined && Theme.backgroundPrimary !== null) ? Theme.backgroundPrimary : "#222"
-                        offsetX: -39
-                        offsetY: 0
-                        anchors.top: parent.top
-                        visible: Settings.settings.showCorners
+                        Corners {
+                            id: topRightCorner
+                            position: "bottomright"
+                            size: 1.3
+                            fillColor: (Theme.backgroundPrimary !== undefined && Theme.backgroundPrimary !== null) ? Theme.backgroundPrimary : "#222"
+                            offsetX: 39
+                            offsetY: 0
+                            anchors.top: parent.top
+                            visible: Settings.settings.showCorners
+                        }
                     }
-                }
 
-                PanelWindow {
-                    id: topRightPanel
-                    anchors.top: true
-                    anchors.right: true
-                    color: "transparent"
-                    screen: modelData
-                    margins.top: 36
-                    WlrLayershell.exclusionMode: ExclusionMode.Ignore
-                    visible: true
-                    WlrLayershell.layer: WlrLayer.Background
-                    aboveWindows: false
-                    WlrLayershell.namespace: "swww-daemon"
+                    PanelWindow {
+                        id: bottomLeftPanel
+                        anchors.bottom: true
+                        anchors.left: true
+                        color: "transparent"
+                        screen: modelData
+                        WlrLayershell.exclusionMode: ExclusionMode.Ignore
+                        visible: true
+                        WlrLayershell.layer: WlrLayer.Background
+                        aboveWindows: false
+                        WlrLayershell.namespace: "swww-daemon"
 
-                    implicitHeight: 24
+                        implicitHeight: 24
 
-                    Corners {
-                        id: topRightCorner
-                        position: "bottomright"
-                        size: 1.3
-                        fillColor: (Theme.backgroundPrimary !== undefined && Theme.backgroundPrimary !== null) ? Theme.backgroundPrimary : "#222"
-                        offsetX: 39
-                        offsetY: 0
-                        anchors.top: parent.top
-                        visible: Settings.settings.showCorners
+                        Corners {
+                            id: bottomLeftCorner
+                            position: "topleft"
+                            size: 1.3
+                            fillColor: Theme.backgroundPrimary
+                            offsetX: -39
+                            offsetY: 0
+                            anchors.top: parent.top
+                            visible: Settings.settings.showCorners
+                        }
                     }
-                }
 
-                PanelWindow {
-                    id: bottomLeftPanel
-                    anchors.bottom: true
-                    anchors.left: true
-                    color: "transparent"
-                    screen: modelData
-                    WlrLayershell.exclusionMode: ExclusionMode.Ignore
-                    visible: true
-                    WlrLayershell.layer: WlrLayer.Background
-                    aboveWindows: false
-                    WlrLayershell.namespace: "swww-daemon"
+                    PanelWindow {
+                        id: bottomRightPanel
+                        anchors.bottom: true
+                        anchors.right: true
+                        color: "transparent"
+                        screen: modelData
+                        WlrLayershell.exclusionMode: ExclusionMode.Ignore
+                        visible: true
+                        WlrLayershell.layer: WlrLayer.Background
+                        aboveWindows: false
+                        WlrLayershell.namespace: "swww-daemon"
 
-                    implicitHeight: 24
+                        implicitHeight: 24
 
-                    Corners {
-                        id: bottomLeftCorner
-                        position: "topleft"
-                        size: 1.3
-                        fillColor: Theme.backgroundPrimary
-                        offsetX: -39
-                        offsetY: 0
-                        anchors.top: parent.top
-                        visible: Settings.settings.showCorners
-                    }
-                }
-
-                PanelWindow {
-                    id: bottomRightPanel
-                    anchors.bottom: true
-                    anchors.right: true
-                    color: "transparent"
-                    screen: modelData
-                    WlrLayershell.exclusionMode: ExclusionMode.Ignore
-                    visible: true
-                    WlrLayershell.layer: WlrLayer.Background
-                    aboveWindows: false
-                    WlrLayershell.namespace: "swww-daemon"
-
-                    implicitHeight: 24
-
-                    Corners {
-                        id: bottomRightCorner
-                        position: "topright"
-                        size: 1.3
-                        fillColor: Theme.backgroundPrimary
-                        offsetX: 39
-                        offsetY: 0
-                        anchors.top: parent.top
-                        visible: Settings.settings.showCorners
+                        Corners {
+                            id: bottomRightCorner
+                            position: "topright"
+                            size: 1.3
+                            fillColor: Theme.backgroundPrimary
+                            offsetX: 39
+                            offsetY: 0
+                            anchors.top: parent.top
+                            visible: Settings.settings.showCorners
+                        }
                     }
                 }
             }

--- a/Settings/Settings.qml
+++ b/Settings/Settings.qml
@@ -68,6 +68,8 @@ Singleton {
 
             property bool showDock: true
             property bool dockExclusive: false
+
+            property var activeScreens: []
         }
     }
 


### PR DESCRIPTION
- It's working fine and could save a lot of memory for users with multiple screen setup.
- There is no UI yet to edit this settings yet, but one can directly edit the list in ~/.config/Noctalia/settings.json to restrict the bar on the selected screen(s)
- Backward compatible for users without this settings (the bar will show on every screen)

I deciced to go with the QS naming convention by using "screen" instead of monitours, output (from Quickshell.screens)