### PR TITLE
Update uptime command

### DIFF
--- a/Widgets/SidePanel/System.qml
+++ b/Widgets/SidePanel/System.qml
@@ -522,18 +522,30 @@ Rectangle {
     }
  
     Process {
-        id: uptimeProcess
- 
-        command: ["sh", "-c", "uptime | awk -F 'up ' '{print $2}' | awk -F ',' '{print $1}' | xargs"]
-        running: false
- 
-        stdout: StdioCollector {
-            onStreamFinished: {
-                uptimeText = this.text.trim();
-                uptimeProcess.running = false;
+    id: uptimeProcess
+    command: ["cat", "/proc/uptime"]
+    running: false
+
+    stdout: StdioCollector {
+        onStreamFinished: {
+            var uptimeSeconds = parseFloat(this.text.trim().split(' ')[0]);
+            
+            var minutes = Math.floor(uptimeSeconds / 60) % 60;
+            var hours = Math.floor(uptimeSeconds / 3600) % 24;
+            var days = Math.floor(uptimeSeconds / 86400);
+            
+            // Format the output
+            if (days > 0) {
+                uptimeText = days + "d " + hours + "h";
+            } else if (hours > 0) {
+                uptimeText = hours + "h " + minutes + "m";
+            } else {
+                uptimeText = minutes + "m";
+            }
+            
+            uptimeProcess.running = false;
             }
         }
- 
     }
  
     Process {


### PR DESCRIPTION
command: ["sh", "-c", "uptime | awk -F 'up ' '{print $2}' | awk -F ',' '{print $1}' | xargs"]

This old command doesn't work if the system's uptime output is in another language. It just outputs nothing, which results in uptime not being displayed.